### PR TITLE
fix: rclone_command.txt

### DIFF
--- a/rclone_command.txt
+++ b/rclone_command.txt
@@ -1,0 +1,4 @@
+# rclone sync 命令示例 (请替换为实际的源与目标)
+# 格式：rclone sync <源地址>: <目标地址>: [其他参数]
+# 示例：
+rclone sync onedrive: cloud: --transfers=4 --buffer-size=256M -P --no-update-modtime -u --size-only --log-level ERROR


### PR DESCRIPTION
Closes #1

Patch generated by `qwen3.6-35b-a3b via local API`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 新增 `rclone sync` 命令示例及格式说明。
  * 示例涵盖 OneDrive 到 cloud 的同步，并展示传输数量、缓冲区、进度显示、修改时间、大小比较和日志级别等配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->